### PR TITLE
Misuv 8160: set SessionId as a mandatory field in SessionDataRequest

### DIFF
--- a/app/uk/gov/hmrc/incometaxsessiondata/models/SessionDataRequest.scala
+++ b/app/uk/gov/hmrc/incometaxsessiondata/models/SessionDataRequest.scala
@@ -18,5 +18,5 @@ package uk.gov.hmrc.incometaxsessiondata.models
 
 import play.api.mvc.{Request, WrappedRequest}
 
-case class SessionDataRequest[A](internalId: String, sessionId: Option[String]
-                                 )(implicit request: Request[A]) extends WrappedRequest[A](request)
+case class SessionDataRequest[A](internalId: String, sessionId: String)
+                                (implicit request: Request[A]) extends WrappedRequest[A](request)

--- a/app/uk/gov/hmrc/incometaxsessiondata/predicates/AuthenticationPredicate.scala
+++ b/app/uk/gov/hmrc/incometaxsessiondata/predicates/AuthenticationPredicate.scala
@@ -53,10 +53,10 @@ class AuthenticationPredicate @Inject()(val authConnector: MicroserviceAuthConne
     implicit val hc: HeaderCarrier = headerExtractor
       .extractHeader(request, request.session)
     authorised().retrieve(affinityGroup and confidenceLevel and internalId) {
-      case Some(AffinityGroup.Agent) ~ _ ~ Some(id) =>
+      case Some(AffinityGroup.Agent) ~ _ ~ Some(id) if hc.sessionId.isDefined =>
         logger.info(s"[AuthenticationPredicate][authenticated] - authenticated as agent")
         f(SessionDataRequest[A](id, hc.sessionId.map(_.value).get))
-      case _ ~ userConfidence ~ Some(id) if minimumConfidenceLevelOpt.exists(minimumConfidenceLevel => userConfidence.level >= minimumConfidenceLevel) =>
+      case _ ~ userConfidence ~ Some(id) if hc.sessionId.isDefined && minimumConfidenceLevelOpt.exists(minimumConfidenceLevel => userConfidence.level >= minimumConfidenceLevel) =>
         logger.info(s"[AuthenticationPredicate][authenticated] - authenticated as individual")
         f(SessionDataRequest[A](id, hc.sessionId.map(_.value).get))
       case _ ~ _ =>

--- a/app/uk/gov/hmrc/incometaxsessiondata/predicates/AuthenticationPredicate.scala
+++ b/app/uk/gov/hmrc/incometaxsessiondata/predicates/AuthenticationPredicate.scala
@@ -22,12 +22,11 @@ import play.api.mvc._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, confidenceLevel, internalId}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthorisationException, AuthorisedFunctions, ConfidenceLevel}
-import uk.gov.hmrc.http.{Authorization, HeaderCarrier}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.incometaxsessiondata.auth.HeaderExtractor
 import uk.gov.hmrc.incometaxsessiondata.config.AppConfig
 import uk.gov.hmrc.incometaxsessiondata.connectors.MicroserviceAuthConnector
 import uk.gov.hmrc.incometaxsessiondata.models.SessionDataRequest
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -56,10 +55,10 @@ class AuthenticationPredicate @Inject()(val authConnector: MicroserviceAuthConne
     authorised().retrieve(affinityGroup and confidenceLevel and internalId) {
       case Some(AffinityGroup.Agent) ~ _ ~ Some(id) =>
         logger.info(s"[AuthenticationPredicate][authenticated] - authenticated as agent")
-        f(SessionDataRequest[A](id, hc.sessionId.map(_.value)))
+        f(SessionDataRequest[A](id, hc.sessionId.map(_.value).get))
       case _ ~ userConfidence ~ Some(id) if minimumConfidenceLevelOpt.exists(minimumConfidenceLevel => userConfidence.level >= minimumConfidenceLevel) =>
         logger.info(s"[AuthenticationPredicate][authenticated] - authenticated as individual")
-        f(SessionDataRequest[A](id, hc.sessionId.map(_.value)))
+        f(SessionDataRequest[A](id, hc.sessionId.map(_.value).get))
       case _ ~ _ =>
         logger.info(s"[AuthenticationPredicate][authenticated] User has confidence level below ${minimumConfidenceLevelOpt}")
         Future(Unauthorized)

--- a/test/mocks/MockMicroserviceAuthConnector.scala
+++ b/test/mocks/MockMicroserviceAuthConnector.scala
@@ -30,13 +30,13 @@ import scala.concurrent.Future
 trait MockMicroserviceAuthConnector extends TestSupport with BeforeAndAfterEach {
 
   val mockMicroserviceAuthConnector: MicroserviceAuthConnector = mock(classOf[MicroserviceAuthConnector])
-  val authResponseWithCL250: Some[AffinityGroup.Individual.type] ~ ConfidenceLevel.L250.type ~ Some[String] = Some(AffinityGroup.Individual) and ConfidenceLevel.L250 and Some("internalId")
-  val authResponseWithCL50: Some[AffinityGroup.Individual.type] ~ ConfidenceLevel.L50.type ~ Some[String] = Some(AffinityGroup.Individual) and ConfidenceLevel.L50 and Some("internalId")
+  val individualAuthResponseWithCL250: Some[AffinityGroup.Individual.type] ~ ConfidenceLevel.L250.type ~ Some[String] = Some(AffinityGroup.Individual) and ConfidenceLevel.L250 and Some("internalId")
+  val individualAuthResponseWithCL50: Some[AffinityGroup.Individual.type] ~ ConfidenceLevel.L50.type ~ Some[String] = Some(AffinityGroup.Individual) and ConfidenceLevel.L50 and Some("internalId")
   val agentResponseWithCL50: Some[AffinityGroup.Agent.type] ~ ConfidenceLevel.L50.type ~ Some[String] = Some(AffinityGroup.Agent) and ConfidenceLevel.L50 and Some("internalId")
 
 
 
-  def mockAuth(response: Future[Any] = Future.successful( authResponseWithCL250 ) ): Future[Nothing] = {
+  def mockAuth(response: Future[Any] = Future.successful( individualAuthResponseWithCL250 ) ): Future[Nothing] = {
     doReturn(response, Nil: _*).when(mockMicroserviceAuthConnector)
       .authorise(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
   }

--- a/test/mocks/MockMicroserviceAuthConnector.scala
+++ b/test/mocks/MockMicroserviceAuthConnector.scala
@@ -34,12 +34,9 @@ trait MockMicroserviceAuthConnector extends TestSupport with BeforeAndAfterEach 
   val individualAuthResponseWithCL50: Some[AffinityGroup.Individual.type] ~ ConfidenceLevel.L50.type ~ Some[String] = Some(AffinityGroup.Individual) and ConfidenceLevel.L50 and Some("internalId")
   val agentResponseWithCL50: Some[AffinityGroup.Agent.type] ~ ConfidenceLevel.L50.type ~ Some[String] = Some(AffinityGroup.Agent) and ConfidenceLevel.L50 and Some("internalId")
 
-
-
   def mockAuth(response: Future[Any] = Future.successful( individualAuthResponseWithCL250 ) ): Future[Nothing] = {
     doReturn(response, Nil: _*).when(mockMicroserviceAuthConnector)
       .authorise(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
   }
-
 
 }

--- a/test/uk/gov/hmrc/incometaxsessiondata/controllers/SessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsessiondata/controllers/SessionControllerSpec.scala
@@ -35,7 +35,7 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
 
   val mockSessionService: SessionService = mock(classOf[SessionService])
   val cc: ControllerComponents = app.injector.instanceOf[ControllerComponents]
-  val headerExtractor : HeaderExtractor = new TestHeaderExtractor()
+  val headerExtractor: HeaderExtractor = new TestHeaderExtractor()
   val authPredicate = new AuthenticationPredicate(mockMicroserviceAuthConnector, cc, appConfig, headerExtractor)
 
   object testSessionController extends SessionController(cc, authPredicate, mockSessionService)
@@ -55,7 +55,7 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
       "Data is returned from the service" in {
         when(mockSessionService.get(any())).thenReturn(Future(Right(Some(testSessionData))))
         mockAuth()
-        val result: Future[Result] = testSessionController.getById("123")(FakeRequest())
+        val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSession)
         status(result) shouldBe OK
       }
     }
@@ -63,7 +63,7 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
       "Empty data is returned from service" in {
         when(mockSessionService.get(any())).thenReturn(Future(Right(None)))
         mockAuth()
-        val result: Future[Result] = testSessionController.getById("123")(FakeRequest())
+        val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSession)
         status(result) shouldBe NOT_FOUND
       }
     }
@@ -71,14 +71,14 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
       "An error is returned from the service" in {
         when(mockSessionService.get(any())).thenReturn(Future(Left(new Error("Error"))))
         mockAuth()
-        val result: Future[Result] = testSessionController.getById("123")(FakeRequest())
+        val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSession)
         status(result) shouldBe INTERNAL_SERVER_ERROR
       }
     }
     "Recover" when {
       "Unexpected error from service" in {
         when(mockSessionService.get(any())).thenReturn(Future.failed(new Error("")))
-        val result: Future[Result] = testSessionController.getById("123")(FakeRequest())
+        val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSession)
         status(result) shouldBe INTERNAL_SERVER_ERROR
       }
     }
@@ -88,27 +88,27 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
     "Return successful" when {
       "the body is correct and the service returns true" in {
         when(mockSessionService.set(any())).thenReturn(Future(true))
-        val result: Future[Result] = testSessionController.set()(FakeRequest().withJsonBody(Json.toJson[SessionData](testSessionData)))
+        val result: Future[Result] = testSessionController.set()(fakeRequestWithActiveSession.withJsonBody(Json.toJson[SessionData](testSessionData)))
         status(result) shouldBe OK
       }
     }
     "Return an error" when {
       "the service fails to set the session" in {
         when(mockSessionService.set(any())).thenReturn(Future(false))
-        val result: Future[Result] = testSessionController.set()(FakeRequest().withJsonBody(Json.toJson[SessionData](testSessionData)))
+        val result: Future[Result] = testSessionController.set()(fakeRequestWithActiveSession.withJsonBody(Json.toJson[SessionData](testSessionData)))
         status(result) shouldBe INTERNAL_SERVER_ERROR
       }
     }
     "return a bad request" when {
       "the request body is invalid" in {
-        val result: Future[Result] = testSessionController.set()(FakeRequest())
+        val result: Future[Result] = testSessionController.set()(fakeRequestWithActiveSession)
         status(result) shouldBe BAD_REQUEST
       }
     }
     "Recover" when {
       "Unexpected error from service" in {
         when(mockSessionService.set(any())).thenReturn(Future.failed(new Error("")))
-        val result: Future[Result] = testSessionController.set()(FakeRequest().withJsonBody(Json.toJson[SessionData](testSessionData)))
+        val result: Future[Result] = testSessionController.set()(fakeRequestWithActiveSession.withJsonBody(Json.toJson[SessionData](testSessionData)))
         status(result) shouldBe INTERNAL_SERVER_ERROR
       }
     }

--- a/test/uk/gov/hmrc/incometaxsessiondata/controllers/SessionControllerSpec.scala
+++ b/test/uk/gov/hmrc/incometaxsessiondata/controllers/SessionControllerSpec.scala
@@ -22,7 +22,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 import play.api.libs.json.Json
 import play.api.mvc.{ControllerComponents, Result}
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.incometaxsessiondata.auth.HeaderExtractor
 import uk.gov.hmrc.incometaxsessiondata.models.SessionData
@@ -80,6 +79,14 @@ class SessionControllerSpec extends MockMicroserviceAuthConnector {
         when(mockSessionService.get(any())).thenReturn(Future.failed(new Error("")))
         val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSession)
         status(result) shouldBe INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "Recover" when {
+      "Unauthorised error when sessionId empty" in {
+        when(mockSessionService.get(any())).thenReturn(Future(Right(Some(testSessionData))))
+        val result: Future[Result] = testSessionController.getById("123")(fakeRequestWithActiveSessionAndEmptySessionId)
+        status(result) shouldBe UNAUTHORIZED
       }
     }
   }

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -44,11 +44,16 @@ trait TestSupport extends AnyWordSpec with AnyWordSpecLike with Matchers with Op
 
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(3, Seconds), interval = Span(5, Millis))
 
-  val fakeRequestWithActiveSession = FakeRequest().withSession(
+  val fakeRequestWithActiveSession: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
     SessionKeys.lastRequestTimestamp -> "1498236506662",
     SessionKeys.authToken -> "Bearer Token"
   ).withHeaders(
     HeaderNames.REFERER -> "/test/url",
-    "X-Session-ID" -> "testSessionId"
+    "X-Session-ID" -> "test1123"
   )
+
+  val fakeRequestWithActiveSessionAndEmptySessionId: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
+    SessionKeys.lastRequestTimestamp -> "1498236506662",
+    SessionKeys.authToken -> "Bearer Token"
+  ).withHeaders(HeaderNames.REFERER -> "/test/url")
 }


### PR DESCRIPTION
- set sessionId as a mandatory in SessionDataRequest;
- update relevant UTs;